### PR TITLE
README typo + minor cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ So far I have used vscode with devcontainer extension to setup the development e
 
 The repository uses gradle and has multiple subprojects.
 
-Most examples are using `OPENAPI_KEY`. Make sure it is present in your environment variable.
+Most examples are using `OPENAI_API_KEY`. Make sure it is present in your environment variable.
 
 
 ## Running the examples

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,9 +5,10 @@
 langchain4j = "1.0.0-beta1"
 tinylog = "2.6.2"
 kotlin = "2.1.10"
+ktfmt = "0.18.0"
 
 [plugins]
-ktfmt = { id = "com.ncorti.ktfmt.gradle", version = "0.18.0" }
+ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
 
 [libraries]
 langchain4j = { module = "dev.langchain4j:langchain4j", version.ref = "langchain4j" }

--- a/rag-examples/src/main/kotlin/Assistant.kt
+++ b/rag-examples/src/main/kotlin/Assistant.kt
@@ -1,3 +1,3 @@
-public interface Assistant {
+interface Assistant {
     fun answer(query: String): String
 }

--- a/rag-examples/src/main/kotlin/Utils.kt
+++ b/rag-examples/src/main/kotlin/Utils.kt
@@ -1,17 +1,11 @@
 import dev.langchain4j.internal.Utils.getOrDefault
-import java.net.URISyntaxException
 import java.nio.file.FileSystems
 import java.nio.file.Path
 import java.nio.file.PathMatcher
-import java.nio.file.Paths
 import java.util.Scanner
 
 object Utils {
-    val OPENAI_API_KEY: String
-
-    init {
-        OPENAI_API_KEY = getOrDefault(System.getenv("OPENAI_API_KEY"), "demo")
-    }
+    val OPENAI_API_KEY: String = getOrDefault(System.getenv("OPENAI_API_KEY"), "demo")
 
     fun startConversationWith(assistant: Assistant) {
         val scanner = Scanner(System.`in`)
@@ -27,20 +21,17 @@ object Utils {
 
             val agentAnswer = assistant.answer(userQuery)
             println("==================================================")
-            println("Assistant: " + agentAnswer)
+            println("Assistant: $agentAnswer")
         }
     }
 
     fun glob(glob: String): PathMatcher {
-        return FileSystems.getDefault().getPathMatcher("glob:" + glob)
+        return FileSystems.getDefault().getPathMatcher("glob:$glob")
     }
 
     fun toPath(relativePath: String): Path {
-        try {
-            val fileUrl = Utils::class.java.getClassLoader().getResource(relativePath)
-            return Paths.get(fileUrl.toURI())
-        } catch (e: URISyntaxException) {
-            throw RuntimeException(e)
-        }
+        val fileUrl = Utils::class.java.classLoader.getResource(relativePath)
+            ?: throw IllegalArgumentException("Resource not found: $relativePath")
+        return Path.of(fileUrl.toURI())
     }
 }

--- a/tutorials/src/main/kotlin/ApiKeys.kt
+++ b/tutorials/src/main/kotlin/ApiKeys.kt
@@ -1,9 +1,3 @@
-import dev.langchain4j.internal.Utils.getOrDefault
-
 object ApiKeys {
-    val OPENAI_API_KEY: String
-
-    init {
-        OPENAI_API_KEY = getOrDefault(System.getenv("OPENAI_API_KEY"), "demo")
-    }
+    val OPENAI_API_KEY: String = System.getenv("OPENAI_API_KEY") ?: "demo"
 }

--- a/tutorials/src/main/kotlin/_03_PromptTemplate.kt
+++ b/tutorials/src/main/kotlin/_03_PromptTemplate.kt
@@ -35,14 +35,14 @@ fun structuredPromptExample(model: ChatLanguageModel) {
                 "- ..."
             ]
     )
-    class CreateRecipePrompt(val dish: String, val ingredients: List<String>) {}
+    class CreateRecipePrompt(val dish: String, val ingredients: List<String>)
 
-    val receipePrompt =
+    val recipePrompt =
         CreateRecipePrompt("salad", listOf("cucumber", "tomato", "feta", "onion", "olives"))
-    println(receipePrompt)
-    println(receipePrompt.dish)
-    println(receipePrompt.ingredients)
-    val prompt = StructuredPromptProcessor.toPrompt(receipePrompt)
+    println(recipePrompt)
+    println(recipePrompt.dish)
+    println(recipePrompt.ingredients)
+    val prompt = StructuredPromptProcessor.toPrompt(recipePrompt)
 
     println(prompt.text())
 
@@ -52,8 +52,8 @@ fun structuredPromptExample(model: ChatLanguageModel) {
 }
 
 fun main(args: Array<String>) {
-
-    if (args.isEmpty()) {
+    val validOptions = setOf("simple", "structured")
+    if (args.isEmpty() || args[0] !in validOptions) {
         println("Incorrect usage; please provide an example type (simple or structured)")
         println("Usage: _03_PromptTemplate simple|structured")
         return
@@ -66,12 +66,8 @@ fun main(args: Array<String>) {
             .modelName(OpenAiChatModelName.GPT_4_O_MINI)
             .build()
 
-    val exampleType = args[0]
-
-    if (exampleType == "simple") {
-        simplePromptExample(model)
-        return
+    when (args[0]) {
+        "simple" -> simplePromptExample(model)
+        "structured" -> structuredPromptExample(model)
     }
-
-    structuredPromptExample(model)
 }

--- a/tutorials/src/main/kotlin/_04_Streaming.kt
+++ b/tutorials/src/main/kotlin/_04_Streaming.kt
@@ -15,7 +15,7 @@ fun main() {
     val responseHandler =
         object : StreamingChatResponseHandler {
             override fun onPartialResponse(message: String) {
-                println("Received message: $message")
+                print(message)
             }
 
             override fun onCompleteResponse(message: ChatResponse) {

--- a/tutorials/src/main/kotlin/_05_Memory.kt
+++ b/tutorials/src/main/kotlin/_05_Memory.kt
@@ -16,7 +16,8 @@ fun main() {
             .modelName(OpenAiChatModelName.GPT_4_O_MINI)
             .build()
 
-    val chatMemory = TokenWindowChatMemory.withMaxTokens(1000, OpenAiTokenizer())
+    val chatMemory =
+        TokenWindowChatMemory.withMaxTokens(1000, OpenAiTokenizer(OpenAiChatModelName.GPT_4_O_MINI))
 
     val systemMessage =
         SystemMessage.from(
@@ -33,7 +34,7 @@ fun main() {
         )
     chatMemory.add(userMessage1)
 
-    println("[User]: " + userMessage1.text())
+    println("[User]: " + userMessage1.singleText())
     print("[LLM]: ")
 
     val futureAiMessage = CompletableFuture<AiMessage>()
@@ -41,7 +42,7 @@ fun main() {
     val responseHandler =
         object : StreamingChatResponseHandler {
             override fun onPartialResponse(message: String) {
-                println("Received message: $message")
+                print(message)
             }
 
             override fun onCompleteResponse(response: ChatResponse) {
@@ -64,7 +65,7 @@ fun main() {
         )
     chatMemory.add(userMessage2)
 
-    println("\n\n[User]: " + userMessage2.text())
+    println("\n\n[User]: " + userMessage2.singleText())
     print("[LLM]: ")
 
     model.chat(chatMemory.messages(), responseHandler)

--- a/tutorials/src/main/kotlin/_06_FewShot.kt
+++ b/tutorials/src/main/kotlin/_06_FewShot.kt
@@ -66,7 +66,7 @@ fun main() {
     val responseHandler =
         object : StreamingChatResponseHandler {
             override fun onPartialResponse(message: String) {
-                println("Received message: $message")
+                print(message)
             }
 
             override fun onCompleteResponse(message: ChatResponse) {

--- a/tutorials/src/main/kotlin/_08_AIServiceEx3.kt
+++ b/tutorials/src/main/kotlin/_08_AIServiceEx3.kt
@@ -28,16 +28,15 @@ fun main() {
     val translation = assistant.translate("Hello, how are you?", "italian")
     println(translation)
 
-    val text: String =
-        """
-        AI, or artificial intelligence, is a branch of computer science that aims to create 
-        machines that mimic human intelligence. This can range from simple tasks such as recognizing 
-        patterns or speech to more complex tasks like making decisions or predictions.
-    """
+    val text = """
+        |AI, or artificial intelligence, is a branch of computer science that aims to create 
+        |machines that mimic human intelligence. This can range from simple tasks such as recognizing 
+        |patterns or speech to more complex tasks like making decisions or predictions.
+        """.trimMargin()
 
     val bulletPoints = assistant.summarize(text, 3)
 
     for (point in bulletPoints) {
-        println("$point")
+        println(point)
     }
 }

--- a/tutorials/src/main/kotlin/_08_AIServiceEx5.kt
+++ b/tutorials/src/main/kotlin/_08_AIServiceEx5.kt
@@ -53,13 +53,14 @@ fun main() {
 
     val assistant = AiServices.create(HotelReviewIssueAnalyzer::class.java, model)
 
-    val review: String =
-        "Our stay at hotel was a mixed experience. The location was perfect, just a stone's throw away " +
-            "from the beach, which made our daily outings very convenient. The rooms were spacious and well-decorated, " +
-            "providing a comfortable and pleasant environment. However, we encountered several issues during our " +
-            "stay. The air conditioning in our room was not functioning properly, making the nights quite uncomfortable. " +
-            "Additionally, the room service was slow, and we had to call multiple times to get extra towels. Despite the " +
-            "friendly staff and enjoyable breakfast buffet, these issues significantly impacted our stay."
+    val review = """
+        |Our stay at hotel was a mixed experience. The location was perfect, just a stone's throw away 
+        |from the beach, which made our daily outings very convenient. The rooms were spacious and well-decorated, 
+        |providing a comfortable and pleasant environment. However, we encountered several issues during our 
+        |stay. The air conditioning in our room was not functioning properly, making the nights quite uncomfortable. 
+        |Additionally, the room service was slow, and we had to call multiple times to get extra towels. Despite the 
+        |friendly staff and enjoyable breakfast buffet, these issues significantly impacted our stay.
+        """.trimMargin()
 
     val issueCategories = assistant.analyzeReview(review)
     println(issueCategories)

--- a/tutorials/src/main/kotlin/_08_AIServiceEx6.kt
+++ b/tutorials/src/main/kotlin/_08_AIServiceEx6.kt
@@ -36,7 +36,6 @@ fun main() {
 
     val recipe =
         assistant.createRecipeFrom("cucumber", "tomato", "feta", "onion", "olives", "lemon")
-
     println(recipe)
 
     val prompt =
@@ -45,6 +44,6 @@ fun main() {
             listOf("cucumber", "tomato", "feta", "onion", "olives", "potatoes")
         )
 
-    val receipe2 = assistant.createRecipe(prompt)
-    print(receipe2)
+    val recipe2 = assistant.createRecipe(prompt)
+    print(recipe2)
 }

--- a/tutorials/src/main/kotlin/_08_AIServiceEx8.kt
+++ b/tutorials/src/main/kotlin/_08_AIServiceEx8.kt
@@ -19,7 +19,7 @@ fun main() {
     val assistant =
         AiServices.builder(AssistantEx8::class.java)
             .chatLanguageModel(model)
-            .chatMemoryProvider { value -> MessageWindowChatMemory.withMaxMessages(10) }
+            .chatMemoryProvider { _ -> MessageWindowChatMemory.withMaxMessages(10) }
             .build()
 
     println(assistant.chat(1, "Hello! My name is Klaus."))


### PR DESCRIPTION
- fixes typo for the OpenAPI key environment variable
- various minor cleanup such as:
  - remove deprecated calls
  - remove redundant code
  - remove leading space on multi-line input text blocks
  - typos